### PR TITLE
Renovate: only update Angular minor and patch versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,11 @@
   "dependencyDashboard": false,
   "labels": ["dependencies"],
   "prCreation": "not-pending",
-  "stabilityDays": 3
+  "stabilityDays": 3,
+  "packageRules": [
+    {
+      "packagePatterns": ["^@angular/"],
+      "updateTypes": ["minor, patch"]
+    }
+  ]
 }


### PR DESCRIPTION
Upgrading Angular major versions involves running `ng update` which Renovate doesn't do.