### PR TITLE
Renovate: don't update peer dependency zone.js

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,6 @@
       "packagePatterns": ["^@angular/"],
       "updateTypes": ["minor, patch"]
     }
-  ]
+  ],
+  "ignoreDeps": ["zone.js"]
 }


### PR DESCRIPTION
Angular right now needs zone.js ~0.10.3, but Renovate wants to update this to ~0.11.3, so ignore it. Might be improved in the future.