### PR TITLE
Renovate: fix versions handling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,14 @@
   "packageRules": [
     {
       "packagePatterns": ["^@angular/"],
-      "updateTypes": ["minor, patch"]
+      "separateMajorMinor": true,
+      "major": {
+        "enabled": false
+      }
+    },
+    {
+      "packageNames": ["typescript"],
+      "allowedVersions": "<4.1.0"
     }
   ],
   "ignoreDeps": ["zone.js"]


### PR DESCRIPTION
* Don't allow TypeScript at or above version 4.1.0.
* Updated procedure for stopping Angular major updates.