### PR TITLE
Renovate: modify schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "prHourlyLimit": 10,
   "stabilityDays": 7,
   "schedule": [
-    "after 3am and before 6am"
+    "after 03:00 and before 06:00"
   ],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,7 @@
   "prHourlyLimit": 10,
   "stabilityDays": 7,
   "schedule": [
-    "after 3am",
-    "before 6am"
+    "after 3am and before 6am"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Now correctly uses an interval as the allowed schedule.