### PR TITLE
Add peer dependency @angular-devkit/core

### DIFF
--- a/HaloAchievementTracker.WebApp.Client/package.json
+++ b/HaloAchievementTracker.WebApp.Client/package.json
@@ -36,6 +36,7 @@
     "@angular/compiler-cli": "11.0.9",
     "@angular/language-service": "11.0.9",
     "@angular-devkit/architect": "0.1100.7",
+    "@angular-devkit/core": "11.0.7",
     "@angular-devkit/build-angular": "0.1100.7",
     "@angular-devkit/schematics": "11.0.7",
     "@angular-eslint/builder": "1.1.0",


### PR DESCRIPTION
Newer versions of @angular-eslint/schematics requires this as peer dependency.