### PR TITLE
CI: remove update Angular check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,3 @@ jobs:
     - name: Lint Angular client
       working-directory: ./HaloAchievementTracker.WebApp.Client
       run: yarn lint
-    - name: Update Angular
-      working-directory: ./HaloAchievementTracker.WebApp.Client
-      run: yarn update:angular


### PR DESCRIPTION
This check introduced build errors for otherwise good builds, since dependencies can be unmet.