### PR TITLE
Modify GitHub Actions to use .NET Core 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        DOTNET_VERSION: [5.0.100]
+        DOTNET_VERSION: [3.1.x]
         NODE_VERSION: [12.x, 14.x]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As specified in b658fcf7ab1d9884e45af44afe07c59ba8aaddec, we need for the time being stick with .NET Core 3.1 as target environment.