### PR TITLE
CI: do not build with Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         DOTNET_VERSION: [3.1.x]
-        NODE_VERSION: [12.x, 14.x, 16.x]
+        NODE_VERSION: [12.x, 14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET ${{ matrix.DOTNET_VERSION }}


### PR DESCRIPTION
As Angular is having issues building with Node 16, we skip that for now.