### PR TITLE
Disable Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "enabled": false,
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
As the project is not actively maintained, we don't need updates continually.